### PR TITLE
Make FORMAT parameter optional

### DIFF
--- a/src/run-teamscale-upload.sh
+++ b/src/run-teamscale-upload.sh
@@ -8,9 +8,12 @@ fi
 chmod +x teamscale-upload;
 
 # mandatory arguments that have to be always present
-ARGS=( "--server" "$SERVER" "--project" "$PROJECT" "--user" "$USER" "--partition" "$PARTITION" "--accesskey" "$ACCESSKEY" "--format" "$FORMAT" )
+ARGS=( "--server" "$SERVER" "--project" "$PROJECT" "--user" "$USER" "--partition" "$PARTITION" "--accesskey" "$ACCESSKEY" )
 
 # optional parameters. We only use them if they have been set
+if [ -n "$FORMAT" ]; then
+  ARGS+=( "--format" "$FORMAT" )
+fi
 if [ -n "$REVISION" ]; then
   ARGS+=( "--commit" "$REVISION" )
 fi


### PR DESCRIPTION
According to https://github.com/cqse/teamscale-upload-action/blob/11a38ae036dcc4f474be7a914c032172bced43da/action.yml#L25 the parameter `format` is optional. I'm using the `teamscale-upload`-CLI with the `--input` parameter. According to the [docs](https://docs.teamscale.com/howto/uploading-external-results/#uploading-multiple-files-with-different-formats) the `--format` parameter is not needed in that case.